### PR TITLE
Update manifest files with github packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test-action:
@@ -16,4 +24,4 @@ jobs:
           helmv3: 3.0.0
           command: |
             echo "Run kubeval"
-            kubeval ./k8s/*.yaml --strict
+            kubeval ./manifests/*.yaml --strict

--- a/manifests/data-api.yaml
+++ b/manifests/data-api.yaml
@@ -30,9 +30,9 @@ spec:
         app: data-api
     spec:
       containers:
-        - image: msftgbb/data-api:latest
+        - image: docker.pkg.github.com/cloudnativegbb/service-layer/service-layer-data-api:pr-gen
           imagePullPolicy: Always
-          name: data-api
+          name: service-layer-data-api
           resources:
             requests:
               memory: "128Mi"

--- a/manifests/data-api.yaml
+++ b/manifests/data-api.yaml
@@ -30,7 +30,7 @@ spec:
         app: data-api
     spec:
       containers:
-        - image: docker.pkg.github.com/cloudnativegbb/service-layer/service-layer-data-api:pr-gen
+        - image: docker.pkg.github.com/cloudnativegbb/service-layer/service-layer-data-api:latest
           imagePullPolicy: Always
           name: service-layer-data-api
           resources:

--- a/manifests/flights-api.yaml
+++ b/manifests/flights-api.yaml
@@ -30,9 +30,9 @@ spec:
         app: flights-api
     spec:
       containers:
-        - image: msftgbb/flights-api:latest
+        - image: docker.pkg.github.com/cloudnativegbb/service-layer/service-layer-flights-api:latest
           imagePullPolicy: Always
-          name: flights-api
+          name: service-layer-flights-api
           resources:
             requests:
               memory: "128Mi"

--- a/manifests/quakes-api.yaml
+++ b/manifests/quakes-api.yaml
@@ -30,9 +30,9 @@ spec:
         app: quakes-api
     spec:
       containers:
-        - image: msftgbb/quakes-api:latest
+        - image: docker.pkg.github.com/cloudnativegbb/service-layer/service-layer-flights-api:latest
           imagePullPolicy: Always
-          name: quakes-api
+          name: service-layer-quakes-api
           resources:
             requests:
               memory: "128Mi"

--- a/manifests/service-tracker-ui.yaml
+++ b/manifests/service-tracker-ui.yaml
@@ -29,9 +29,9 @@ spec:
         app: service-tracker-ui
     spec:
       containers:
-        - image: msftgbb/service-tracker-ui:20200226173009f369e0
+        - image: docker.pkg.github.com/cloudnativegbb/arcdemo-service-tracker-ui/service-tracker-web:latest
           imagePullPolicy: Always
-          name: service-tracker-ui
+          name: service-tracker-web 
           resources:
             requests:
               memory: "128Mi"

--- a/manifests/weather-api.yaml
+++ b/manifests/weather-api.yaml
@@ -30,9 +30,9 @@ spec:
         app: weather-api
     spec:
       containers:
-        - image: msftgbb/weather-api:latest
+        - image: docker.pkg.github.com/cloudnativegbb/service-layer/service-layer-weather-api:latest
           imagePullPolicy: Always
-          name: weather-api
+          name: service-layer-weather-api
           resources:
             requests:
               memory: "128Mi"


### PR DESCRIPTION
These manifest files now point to the correct github packages. When you push to `master` in the Service Tracker repos, the action explicitly tags that image as `latest` so this should grab the latest version. 